### PR TITLE
Fix to respect delay option when using callback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ node_js:
   - 4.2
   - 6
   - 8
+  - 10
+  - 12
 sudo: false
 after_success: "npm run coveralls"

--- a/index.js
+++ b/index.js
@@ -61,7 +61,9 @@ function verbFunc(verb) {
 					callback.apply(this, arguments);
 				} else {
 					attempts++;
-					return request(params, params.callback);
+					return setTimeout(() => {
+						request(params, params.callback);
+					}, attempts * delay);
 				}
 			};
 			attempts++;

--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ function verbFunc(verb) {
 					callback.apply(this, arguments);
 				} else {
 					attempts++;
+					logFunction(err || 'request-retry-stream is retrying to perform request');
 					return setTimeout(() => {
 						request(params, params.callback);
 					}, attempts * delay);


### PR DESCRIPTION
A small fix to ensure that the `delay` option is used when the functions are used with a callback.

The error appeared in this commit:
https://github.com/debitoor/request-retry-stream/commit/f139d1d95e913e5f2a1cc7a1a2da4f1066ad21ae